### PR TITLE
Fixes UPDATES when custom primary key is used.

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -408,7 +408,7 @@ module.exports = function(connection_,settings_) {
                     //Yaaay, alle Tests bestanden gogo, insert!
                     lastQry = connection.query('UPDATE ?? SET ? WHERE ?? = ?', [req.params.table , updateJson, updateSelector.field, updateSelector.value] , function (err) {
                         if (err) return sendError(res,err.code);
-                        sendSuccessAnswer(req.params.table , res, req.params.id);
+                        sendSuccessAnswer(req.params.table , res, req.params.id, updateSelector.field);
 
                     });
                 }


### PR DESCRIPTION
While updateSelector.field is used on the UPDATE query, it is not used on the following sendSuccessAnswer GET query (it fallbacks to id)